### PR TITLE
feature: I18N Korean

### DIFF
--- a/libs/i18n/index.ts
+++ b/libs/i18n/index.ts
@@ -3,8 +3,9 @@ import {createI18n} from "vue-i18n";
 import zhHans from './zh_hans.json'
 import zhHant from './zh_hant.json'
 import en from './en.json'
+import ko from './ko.json'
 
-const i18n = createI18n<typeof zhHans, 'zh-cn' | 'zh-tw' | 'en'>({
+const i18n = createI18n<typeof zhHans, 'zh-cn' | 'zh-tw' | 'en' | 'ko'>({
   legacy: false,
   locale: 'zh-cn',
   fallbackLocale: 'en',
@@ -12,6 +13,7 @@ const i18n = createI18n<typeof zhHans, 'zh-cn' | 'zh-tw' | 'en'>({
     'zh-cn': zhHans,
     'zh-tw': zhHant,
     'en': en,
+    'ko': ko
   }
 })
 

--- a/libs/i18n/ko.json
+++ b/libs/i18n/ko.json
@@ -1,0 +1,202 @@
+{
+    "public": {
+        "search": "Search",
+        "followers": "Followers",
+        "following": "Following",
+        "members": "Members",
+        "statuses_count": "Status count",
+        "deleted": "Deleted",
+        "protected": "Protected",
+        "retry": "Retry",
+        "profile": "Profile",
+        "tweet": "Tweet",
+        "error": "error",
+        "translate": "Translate",
+        "loading": "Loading",
+        "timestamp": "Timestamp",
+        "original": "Original",
+        "retweet": "Retweets",
+        "media": "Media",
+        "username": "Username",
+        "group": "Group",
+        "user_list": "User list",
+        "and": "and",
+        "time": {
+            "second": "second | seconds",
+            "minute": "minute | minutes",
+            "hour": "hour | hours",
+            "day": "day | days"
+        }
+    },
+    "timeline": {
+        "message": {
+            "not_exist": "{0}은(는) 존재하지 않습니다.",
+            "no_longer_monitor_deleted": "해당계정은 삭제되었으며, 오랫동안 모니터링 되지 않았습니다",
+            "no_longer_monitor_protected": "해당계정은 보호되었으며, 오랫동안 모니터링 되지 않았습니다",
+            "load_more": "자세히",
+            "no_more": "컨텐츠 없음"
+        },
+        "nav_bar": {
+            "all": "All",
+            "original": "Original",
+            "retweet": "Retweets",
+            "media": "Media",
+            "album": "Album",
+            "spaces": "Spaces",
+            "no_image": "No image",
+            "include_reply": "Replies"
+        },
+        "side_tags": {
+            "home": "Home",
+            "trends": "Trends",
+            "search": "Search",
+            "settings": "Settings",
+            "about": "About",
+            "bookmarks": "Bookmarks",
+            "stats": "Stats",
+            "status": "Status",
+            "api": "API",
+            "media_download_tool": "Media tools",
+            "rss": "RSS",
+            "backstage": "Backstage",
+            "tools": "Tools"
+        },
+        "scripts": {
+            "time": "Time",
+            "message": {
+                "update_tweets": "{count} tweet loaded | {count} tweets loaded",
+                "missing_parameter": "파라메터 부재",
+                "failed_to_generate_chart": "차트생성 실패 #{0}"
+            }
+        }
+    },
+    "translate": {
+        "message": {
+            "translate_by": "Translated by {0}",
+            "clean": "Clean translate",
+            "hide_translated": "Hide translated Tweet",
+            "translate_profile": "Translate bio",
+            "translate_tweet": "Translate Tweet"
+        }
+    },
+    "userinfo": {
+        "message": {
+            "load_success": "Load {0} ({'@'}{1}) success"
+        }
+    },
+    "candlestick_chart": {
+        "chart": {
+            "candle_sticks": "Candle sticks"
+        }
+    },
+    "project_list": {
+        "button": {
+            "select_project": "프로젝트 선택"
+        }
+    },
+    "quote_card": {
+        "card": {
+            "this_tweet_is_not_available": "트윗 사용불가"
+        }
+    },
+    "search": {
+        "normal_search": {
+            "input_text_here": "검색어를 입력해주세요",
+            "select": "Select",
+            "search_by_text": "텍스트 검색",
+            "search_by_date": "날짜 검색",
+            "advanced_search": "고급 검색"
+        },
+        "advanced_search": {
+            "all_of_these_words": "해당 단어를 전부 검색합니다",
+            "example_text_include": "예시: 서울 지하철 · 단어 전부 포함 “서울” and “지하철”",
+            "from_this_accounts": "해당 계정에 대해 검색합니다",
+            "example_from_this_accounts": "예시: {'@'}Twitter",
+            "clean": "초기화",
+            "example_search_time": "예시: 2021-01-01 -> 2021-01-02",
+            "nav_bar": {
+                "all": "All",
+                "original": "Original",
+                "retweet": "Retweets",
+                "media_only": "Media only",
+                "reverse": "Reverse",
+                "hidden": "Hidden tweets"
+            },
+            "tips": {
+                "line1": {
+                    "text": "* {or_mode} : “a OR b”, {and_mode} : “a AND b”，{not_mode} “제외 (a NOT b)” 또는 “NOT (a AND b)”",
+                    "or_mode": "OR mode",
+                    "and_mode": "AND mode",
+                    "not_mode": "NOT mode"
+                },
+                "line2": "* 공백문자(스페이스바)를 사용하여 단어를 구분합니다"
+            },
+            "search": "검색하기"
+        },
+        "nav_list": {
+            "search_by_tag": "태그로 검색 {0}",
+            "search_by_tweet_id": "트윗 ID로 검색 {0}",
+            "search_by_text": "{0} 검색하기"
+        },
+        "tips": {
+            "tips": "팁",
+            "tips_sub_title": "검색모드 사용법",
+            "line1": "{at}은 트위터 유저명, ID, 등을 이용하여 유저를 검색할 수 있고 정규표현식을 지원합니다",
+            "line2": "{hashtag}은 해시태그를 검색할 수 있습니다",
+            "line3": "{cashtag} 캐시태그를 검색할 수 있습니다, 캐시태그란 주가(예시: $TWTR) 또는 암호화폐(예시: $BTC)",
+            "line4": "텍스트를 입력하거나, {at_username} 필터를 추가할 수 있습니다",
+            "line5": "텍스트를 입력하거나, 트위터 아이디를 검색해서 현재 트윗을 검색할 수 있습니다",
+            "line6": "{help_en} 또는 {help_zh} 버튼을 눌러 해당팁을 볼 수 있습니다"
+        }
+    },
+    "tw_card": {
+        "text": {
+            "unsupported_type": "지원하지 않는 타입",
+            "list": "List",
+            "members_count": "{count} member | {count} members",
+            "someone_s_space": "{someone} 's space",
+            "view_community": "View Community"
+        }
+    },
+    "tweet": {
+        "text": {
+            "pinned_tweet": "핀 트윗",
+            "this_is_a_dispute_tweet": "해당 트윗은 논쟁의 여지가 있는 트윗입니다",
+            "learn_more": "더 알아보기",
+            "replying_to": "답장하기"
+        },
+        "interactive": {
+            "retweet": "Retweet | Retweets",
+            "quote": "Quote Tweet | Quote Tweets",
+            "favorite": "Like | Likes"
+        }
+    },
+    "polls": {
+        "vote": "{count} vote | {count} votes",
+        "final_results": "최종결과",
+        "wait_for_sync": "싱크중",
+        "eta": "{0} left"
+    },
+    "notice": {
+        "nothing_here": "요청하신 페이지를 찾을 수 없습니다.",
+        "internet_speed_is_too_slow_now_image_display_has_been_turned_off": "현재 네트워크 속도가 현저히 느려, 이미지 디스플레이를 임시로 차단시켰습니다."
+    },
+    "settings": {
+        "language": "언어",
+        "api_path": "API 경로",
+        "default_api_path": "기본 API 경로: {0}",
+        "media_path": "미디어 경로",
+        "default_media_path": "기본 미디어 경로: {0}",
+        "auto_refresh": "자동갱신 타임라인",
+        "auto_load_tweets": "트윗 하단에 자동 불러오기",
+        "load_conversation": "상태가 변경된 트윗 불러오기",
+        "online_mode": "온라인 API 사용하기",
+        "translator_platform": "번역기"
+    },
+    "pwa": {
+        "need_refresh": "새로운 컨텐츠를 사용할 수 있습니다, 해당 페이지를 새로고침 해주세요."
+    },
+    "community": {
+        "rules": "Rules"
+    }
+}


### PR DESCRIPTION
## Implement Internationalization(aka I18N) for Twitter Monitor Frontend

This Pull Request introduces internationalization (I18N) support to the Twitter Monitor Frontend application.
The following changes have been made to enhance the user experience for a global audience:

Created translation files for supported languages (e.g., Chinese Traditional, Chinese Simplified, English, Korean).

### Additional Notes:
Korean doesn't need to translate the navigation (tap included) part. Most Koreans already know the meaning.

### Coming Soon:
The I18N of Japanese will take place.